### PR TITLE
Add cache_path for instance store

### DIFF
--- a/parallel-cluster-post-install.sh
+++ b/parallel-cluster-post-install.sh
@@ -119,7 +119,7 @@ do
 "qdel_cmd_tpl": "scancel {{ cluster_job_id }}",
 "worker_bin_path": "@CRYOSPARC_INSTALL_PATH@/cryosparc_worker/bin/cryosparcw",
 "title": "cryosparc-cluster",
-"cache_path": "",
+"cache_path": "/scratch",
 "qinfo_cmd_tpl": "sinfo",
 "qsub_cmd_tpl": "sbatch {{ script_path_abs }}",
 "qstat_cmd_tpl": "squeue -j {{ cluster_job_id }}",


### PR DESCRIPTION
All compute resources in the ParallelCluster/slurm queues have their SSD/NVMe storage configured to be hosted on /scratch. This adds the information to CryoSparc to enable to use this cache for storing (intermediate) results.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
